### PR TITLE
Don't include null as return type

### DIFF
--- a/lib/TestClassMetadataParser.php
+++ b/lib/TestClassMetadataParser.php
@@ -103,9 +103,9 @@ class TestClassMetadataParser
                 if (! class_exists($returnTypeName)) {
                     continue;
                 }
+                
+                $useStatements[] = $returnType;
             }
-
-            $useStatements[] = $returnType;
         }
 
         $useStatements[] = MockObject::class;


### PR DESCRIPTION
If $returnType === null, this will be added to the class which results in an error in code generation later.